### PR TITLE
Fix XML file syntax errors.  Add 13-BM files.

### DIFF
--- a/doc/demo/areadetector/13-BM/tomoDetectorAttributes.xml
+++ b/doc/demo/areadetector/13-BM/tomoDetectorAttributes.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" standalone="no" ?>
+<!-- Attributes -->
+<Attributes>
+    <Attribute name="DetectorManufacturer"          type="EPICS_PV"     source="$(DET)cam1:Manufacturer_RBV"             dbrtype="DBR_STRING"  description="Detector manufacturer"/>
+    <Attribute name="DetectorModel"                 type="EPICS_PV"     source="$(DET)cam1:Model_RBV"                    dbrtype="DBR_STRING"  description="Detector model"/>
+    <Attribute name="SerialNumber"                  type="EPICS_PV"     source="$(DET)cam1:SerialNumber_RBV"             dbrtype="DBR_STRING"  description="Detector serial number"/>
+    <Attribute name="FirmwareVersion"               type="EPICS_PV"     source="$(DET)cam1:FirmwareVersion_RBV"          dbrtype="DBR_STRING"  description="Detector firmware version"/>
+    <Attribute name="SDKVersion"                    type="EPICS_PV"     source="$(DET)cam1:SDKVersion_RBV"               dbrtype="DBR_STRING"  description="Detector vendor SDK version"/>
+    <Attribute name="DriverVersion"                 type="EPICS_PV"     source="$(DET)cam1:DriverVersion_RBV"            dbrtype="DBR_STRING"  description="areaDetector driver version"/>
+    <Attribute name="ADCoreVersion"                 type="EPICS_PV"     source="$(DET)cam1:ADCoreVersion_RBV"            dbrtype="DBR_STRING"  description="areaDetector ADCore version"/>
+
+    <Attribute name="MaxSizeX"                      type="EPICS_PV"     source="$(DET)cam1:MaxSizeX_RBV"                 dbrtype="DBR_NATIVE"  description="Detector total X pixels"/>
+    <Attribute name="MaxSizeY"                      type="EPICS_PV"     source="$(DET)cam1:MaxSizeY_RBV"                 dbrtype="DBR_NATIVE"  description="Detector total Y pixels"/>
+    <Attribute name="MinX"                          type="EPICS_PV"     source="$(DET)cam1:MinX"                         dbrtype="DBR_NATIVE"  description="Detector readout min X"/>
+    <Attribute name="MinY"                          type="EPICS_PV"     source="$(DET)cam1:MinY"                         dbrtype="DBR_NATIVE"  description="Detector readout min Y"/>
+    <Attribute name="SizeX"                         type="EPICS_PV"     source="$(DET)cam1:SizeX"                        dbrtype="DBR_NATIVE"  description="Detector readout size X"/>
+    <Attribute name="SizeY"                         type="EPICS_PV"     source="$(DET)cam1:SizeY"                        dbrtype="DBR_NATIVE"  description="Detector readout size Y"/>
+    <Attribute name="BinX"                          type="EPICS_PV"     source="$(DET)cam1:BinX"                         dbrtype="DBR_NATIVE"  description="Detector readout bin X"/>
+    <Attribute name="BinY"                          type="EPICS_PV"     source="$(DET)cam1:BinY"                         dbrtype="DBR_NATIVE"  description="Detector readout bin Y"/>
+
+    <Attribute name="AcquireTime"                   type="EPICS_PV"     source="$(DET)cam1:AcquireTime_RBV"              dbrtype="DBR_NATIVE"  description="Exposure time"/>
+    <Attribute name="AcquirePeriod"                 type="EPICS_PV"     source="$(DET)cam1:AcquirePeriod_RBV"            dbrtype="DBR_NATIVE"  description="Exposure period"/>
+    <Attribute name="ExposurePeriod"                type="EPICS_PV"     source="13BMD:SIS1:Dwell"                        dbrtype="DBR_NATIVE"  description="SIS Dwell=exposure period"/>
+    <Attribute name="FrameRate"                     type="EPICS_PV"     source="$(DET)cam1:FrameRate_RBV"                dbrtype="DBR_NATIVE"  description="Frame rate"/>
+    <Attribute name="FrameRateEnable"               type="EPICS_PV"     source="$(DET)cam1:FrameRateEnable_RBV"          dbrtype="DBR_STRING"  description="Frame rate enable"/>
+    <Attribute name="Gain"                          type="EPICS_PV"     source="$(DET)cam1:Gain_RBV"                     dbrtype="DBR_NATIVE"  description="Gain"/>
+    <Attribute name="GainAuto"                      type="EPICS_PV"     source="$(DET)cam1:GainAuto_RBV"                 dbrtype="DBR_NATIVE"  description="Gain auto"/>
+    <Attribute name="PixelFormat"                   type="EPICS_PV"     source="$(DET)cam1:PixelFormat_RBV"              dbrtype="DBR_STRING"  description="Readout pixel format"/>
+    <Attribute name="ConvertPixelFormat"            type="EPICS_PV"     source="$(DET)cam1:ConvertPixelFormat_RBV"       dbrtype="DBR_STRING"  description="Converted pixel format"/>
+    <Attribute name="ArrayCounter"                  type="EPICS_PV"     source="$(DET)cam1:ArrayCounter_RBV"             dbrtype="DBR_NATIVE"  description="Frames collected to date"/>
+    <Attribute name="DetectorTemperature"           type="EPICS_PV"     source="$(DET)cam1:TemperatureActual"            dbrtype="DBR_NATIVE"  description="Detector temperature"/>
+
+    <Attribute name="FrameType"                     type="EPICS_PV"     source="$(DET)cam1:FrameType"                    dbrtype="DBR_STRING"  description="Frame type"/>
+    <Attribute name="FileName"                      type="EPICS_PV"     source="$(DET)HDF1:FileName"                     dbrtype="DBR_STRING"  description="File name "/>
+    <Attribute name="FullFileName"                  type="EPICS_PV"     source="$(DET)HDF1:FullFileName_RBV"             dbrtype="DBR_STRING"  description="Full file name"/>
+    <Attribute name="FilePath"                      type="EPICS_PV"     source="$(DET)HDF1:FilePath_RBV"                 dbrtype="DBR_STRING"  description="File path"/>
+    <Attribute name="HDFPluginVersion"              type="EPICS_PV"     source="$(DET)HDF1:PluginType_RBV"               dbrtype="DBR_STRING"  description="File plugin type"/>
+
+    <Attribute name="DateTimeStart"                 type="EPICS_PV"     source="S:IOC:timeOfDayForm1SI"                  dbrtype="DBR_STRING"  description="Date and time at start"/>
+    <Attribute name="DateTimeEnd"                   type="EPICS_PV"     source="S:IOC:timeOfDayForm1SI"                  dbrtype="DBR_STRING"  description="Date and time at end"/>
+    <Attribute name="RingCurrent"                   type="EPICS_PV"     source="S:SRcurrentAI"                           dbrtype="DBR_NATIVE"  description="Ring current"/>
+    <Attribute name="TopUpStatus"                   type="EPICS_PV"     source="S:TopUpStatus"                           dbrtype="DBR_STRING"  description="Top-up status"/>
+    <Attribute name="BeamMode"                      type="EPICS_PV"     source="OPS:message3"                            dbrtype="DBR_STRING"  description="Beam mode"/>
+
+    <Attribute name="SampleX"                       type="EPICS_PV"     source="13BMD:m85.RBV"                           dbrtype="DBR_NATIVE"  description="Bottom X stage translation"/>
+    <Attribute name="SampleOmega"                   type="EPICS_PV"     source="13BMD:m38.RBV"                           dbrtype="DBR_NATIVE"  description="Sample rotation"/>
+    <Attribute name="SampleY"                       type="EPICS_PV"     source="13BMD:m90.VAL"                           dbrtype="DBR_NATIVE"  description="Sample vertical height"/>
+    <Attribute name="SampleXCent"                   type="EPICS_PV"     source="13BMD:m92.VAL"                           dbrtype="DBR_NATIVE"  description="Sample X centering"/>
+    <Attribute name="SampleZCent"                   type="EPICS_PV"     source="13BMD:m93.VAL"                           dbrtype="DBR_NATIVE"  description="Sample Z centering"/>
+
+    <Attribute name="CameraX"                       type="EPICS_PV"     source="13BMD:m33.VAL"                           dbrtype="DBR_NATIVE"  description="Camera X position"/>
+    <Attribute name="CameraY"                       type="EPICS_PV"     source="13BMD:m34.VAL"                           dbrtype="DBR_NATIVE"  description="Camera Y (focus) position"/>
+    <Attribute name="CameraZ"                       type="EPICS_PV"     source="13BMD:m35.VAL"                           dbrtype="DBR_NATIVE"  description="Camera Z position"/>
+    <Attribute name="CameraDistance"                type="EPICS_PV"     source="13BMD:m70.VAL"                           dbrtype="DBR_NATIVE"  description="Camera distance"/>
+    <Attribute name="CameraRotation"                type="EPICS_PV"     source="13BMD:m37.VAL"                           dbrtype="DBR_NATIVE"  description="Camera rotation"/>
+
+    <Attribute name="ScintillatorType"              type="EPICS_PV"     source="$(TC)ScintillatorType"                   dbrtype="DBR_STRING"  description="Scintillator type"/>
+    <Attribute name="ScintillatorThickness"         type="EPICS_PV"     source="$(TC)ScintillatorThickness"              dbrtype="DBR_NATIVE"  description="Scintillator thickness (microns)"/>
+    <Attribute name="ImagePixelSize"                type="EPICS_PV"     source="$(TC)ImagePixelSize"                     dbrtype="DBR_NATIVE"  description="Pixel size on sample (microns)"/>
+    <Attribute name="DetectorPixelSize"             type="EPICS_PV"     source="$(TC)DetectorPixelSize"                  dbrtype="DBR_NATIVE"  description="Detector pixel size (microns)"/>
+    <Attribute name="CameraObjective"               type="EPICS_PV"     source="$(TC)CameraObjective"                    dbrtype="DBR_STRING"  description="Objective type"/>
+    <Attribute name="CameraTubeLength"              type="EPICS_PV"     source="$(TC)CameraTubeLength"                   dbrtype="DBR_NATIVE"  description="Tube length (mm)"/>
+
+    <Attribute name="LiftHeight"                    type="EPICS_PV"     source="13BMD:m22.VAL"                           dbrtype="DBR_NATIVE"  description="Lift table height"/>
+    <Attribute name="LiftX"                         type="EPICS_PV"     source="13BMD:XAS:t1.EX"                         dbrtype="DBR_NATIVE"  description="Lift table X"/>
+    <Attribute name="LiftAX"                        type="EPICS_PV"     source="13BMD:XAS:t1.EAX"                        dbrtype="DBR_NATIVE"  description="Lift table AX"/>
+    <Attribute name="LiftY"                         type="EPICS_PV"     source="13BMD:XAS:t1.EY"                         dbrtype="DBR_NATIVE"  description="Lift table Y"/>
+    <Attribute name="LiftAY"                        type="EPICS_PV"     source="13BMD:XAS:t1.EAY"                        dbrtype="DBR_NATIVE"  description="Lift table AY"/>
+    <Attribute name="LiftZ"                         type="EPICS_PV"     source="13BMD:XAS:t1.EZ"                         dbrtype="DBR_NATIVE"  description="Lift table Z"/>
+    <Attribute name="LiftAZ"                        type="EPICS_PV"     source="13BMD:XAS:t1.EAZ"                        dbrtype="DBR_NATIVE"  description="Lift table AZ"/>
+
+    <Attribute name="Energy"                        type="EPICS_PV"     source="13BMA:E:E_RBV"                           dbrtype="DBR_NATIVE"  description="Monochromator energy"/>
+    <Attribute name="EnergyMode"                    type="EPICS_PV"     source="$(TC)EnergyMode"                         dbrtype="DBR_STRING"  description="Energy mode"/>
+    <Attribute name="BeamOffset"                    type="EPICS_PV"     source="13BMA:E:height"                          dbrtype="DBR_NATIVE"  description="Monochromator offset"/>
+    <Attribute name="MonoFBSetpoint"                type="EPICS_PV"     source="13BMA:mono_pid1.VAL"                     dbrtype="DBR_NATIVE"  description="Mono feedback setpoint"/>
+    <Attribute name="MonoFBReadback"                type="EPICS_PV"     source="13BMA:mono_pid1.CVAL"                    dbrtype="DBR_NATIVE"  description="Mono feedback readback"/>
+    <Attribute name="MonoFBOnOff"                   type="EPICS_PV"     source="13BMA:mono_pid1.FBON"                    dbrtype="DBR_STRING"  description="Mono feedback on/off"/>
+    <Attribute name="KeithleyGain"                  type="EPICS_PV"     source="13BMD:A3sens_num.VAL"                    dbrtype="DBR_STRING"  description="Keithley gain"/>
+    <Attribute name="KeithleyUnits"                 type="EPICS_PV"     source="13BMD:A3sens_unit.VAL"                   dbrtype="DBR_STRING"  description="Keithley units"/>
+
+    <Attribute name="Filter"                        type="EPICS_PV"     source="13BMA:BMD_FiltersSelect"                 dbrtype="DBR_NATIVE"  description="Filter"/>
+    <Attribute name="FilterMotor"                   type="EPICS_PV"     source="13BMA:m5.RBV"                            dbrtype="DBR_NATIVE"  description="Filter motor position"/>
+
+    <Attribute name="MirrorHeight"                  type="EPICS_PV"     source="13BMA:pm3.RBV"                           dbrtype="DBR_NATIVE"  description="Mirror height"/>
+    <Attribute name="MirrorPitch"                   type="EPICS_PV"     source="13BMA:pm4.RBV"                           dbrtype="DBR_NATIVE"  description="Mirror pitch"/>
+    <Attribute name="MirrorCurvature"               type="EPICS_PV"     source="13BMA:pm1.RBV"                           dbrtype="DBR_NATIVE"  description="Mirror curvature"/>
+    <Attribute name="MirrorEllipticity"             type="EPICS_PV"     source="13BMA:pm2.RBV"                           dbrtype="DBR_NATIVE"  description="Mirror ellipticity"/>
+
+    <Attribute name="BMDSlitHSize"                  type="EPICS_PV"     source="13BMD:BMDHsize.VAL"                      dbrtype="DBR_NATIVE"  description="BMD horizontal slit size"/>
+    <Attribute name="BMDSlitVSize"                  type="EPICS_PV"     source="13BMD:BMDVsize.VAL"                      dbrtype="DBR_NATIVE"  description="BMD vertical slit size"/>
+    <Attribute name="BMDSlitHCenter"                type="EPICS_PV"     source="13BMD:BMDHcenter.VAL"                    dbrtype="DBR_NATIVE"  description="BMD horizontal slit center"/>
+    <Attribute name="BMDSlitVCenter"                type="EPICS_PV"     source="13BMD:BMDVcenter.VAL"                    dbrtype="DBR_NATIVE"  description="BMD vertical slit center"/>
+
+    <Attribute name="RotationStart"                 type="EPICS_PV"     source="$(TC)RotationStart"                      dbrtype="DBR_NATIVE"  description="Rotation start position"/>
+    <Attribute name="RotationStep"                  type="EPICS_PV"     source="$(TC)RotationStep"                       dbrtype="DBR_NATIVE"  description="Rotation step size"/>
+    <Attribute name="RotationSpeed"                 type="EPICS_PV"     source="13BMD:m38.VELO"                          dbrtype="DBR_NATIVE"  description="Rotation speed"/>
+    <Attribute name="NumAngles"                     type="EPICS_PV"     source="$(TC)NumAngles"                          dbrtype="DBR_NATIVE"  description="Number of projections"/>
+    <Attribute name="ReturnRotation"                type="EPICS_PV"     source="$(TC)ReturnRotation"                     dbrtype="DBR_STRING"  description="Return rotation to start after scan"/>
+
+    <Attribute name="NumDarkFields"                 type="EPICS_PV"     source="$(TC)NumDarkFields"                      dbrtype="DBR_NATIVE"  description="Number of dark fields"/>
+    <Attribute name="DarkFieldMode"                 type="EPICS_PV"     source="$(TC)DarkFieldMode"                      dbrtype="DBR_STRING"  description="Dark field mode"/>
+    <Attribute name="DarkFieldValue"                type="EPICS_PV"     source="$(TC)DarkFieldValue"                     dbrtype="DBR_NATIVE"  description="Dark field value"/>
+
+    <Attribute name="NumFlatFields"                 type="EPICS_PV"     source="$(TC)NumFlatFields"                      dbrtype="DBR_NATIVE"  description="Number of flat fields"/>
+    <Attribute name="FlatFieldMode"                 type="EPICS_PV"     source="$(TC)FlatFieldMode"                      dbrtype="DBR_STRING"  description="Flat field mode"/>
+    <Attribute name="FlatFieldValue"                type="EPICS_PV"     source="$(TC)FlatFieldValue"                     dbrtype="DBR_NATIVE"  description="Flat field value"/>
+    <Attribute name="FlatFieldAxis"                 type="EPICS_PV"     source="$(TC)FlatFieldAxis"                      dbrtype="DBR_STRING"  description="Flat field axis"/>
+    <Attribute name="SampleInX"                     type="EPICS_PV"     source="$(TC)SampleInX"                          dbrtype="DBR_NATIVE"  description="Sample in X position"/>
+    <Attribute name="SampleOutX"                    type="EPICS_PV"     source="$(TC)SampleOutX"                         dbrtype="DBR_NATIVE"  description="Sample out X position"/>
+    <Attribute name="SampleInY"                     type="EPICS_PV"     source="$(TC)SampleInY"                          dbrtype="DBR_NATIVE"  description="Sample in Y position"/>
+    <Attribute name="SampleOutY"                    type="EPICS_PV"     source="$(TC)SampleOutY"                         dbrtype="DBR_NATIVE"  description="Sample out Y position"/>
+
+    <Attribute name="SampleName"                    type="EPICS_PV"     source="$(TC)SampleName"                         dbrtype="DBR_STRING"  description="Sample name"/>
+    <Attribute name="SampleDescription1"            type="EPICS_PV"     source="$(TC)SampleDescription1"                 dbrtype="DBR_STRING"  description="Sample description 1"/>
+    <Attribute name="SampleDescription2"            type="EPICS_PV"     source="$(TC)SampleDescription2"                 dbrtype="DBR_STRING"  description="Sample description 2"/>
+    <Attribute name="SampleDescription3"            type="EPICS_PV"     source="$(TC)SampleDescription3"                 dbrtype="DBR_STRING"  description="Sample description 3"/>
+
+    <Attribute name="UserName"                      type="EPICS_PV"     source="$(TC)UserName"                           dbrtype="DBR_STRING"  description="User names"/>
+    <Attribute name="UserAffiliation"               type="EPICS_PV"     source="$(TC)UserInstitution"                    dbrtype="DBR_STRING"  description="User institution"/>
+    <Attribute name="UserBadge"                     type="EPICS_PV"     source="$(TC)UserBadge"                          dbrtype="DBR_STRING"  description="User badge number"/>
+    <Attribute name="UserEmail"                     type="EPICS_PV"     source="$(TC)UserEmail"                          dbrtype="DBR_STRING"  description="User e-mail"/>
+    <Attribute name="ProposalNumber"                type="EPICS_PV"     source="$(TC)ProposalNumber"                     dbrtype="DBR_STRING"  description="Proposal number"/>
+    <Attribute name="ProposalTitle"                 type="EPICS_PV"     source="$(TC)ProposalTitle"                      dbrtype="DBR_STRING"  description="Proposal title"/>
+    <Attribute name="ESAFNumber"                    type="EPICS_PV"     source="$(TC)ESAFNumber"                         dbrtype="DBR_STRING"  description="ESAF number"/>
+
+</Attributes>
+    
+    

--- a/doc/demo/areadetector/13-BM/tomoLayout.xml
+++ b/doc/demo/areadetector/13-BM/tomoLayout.xml
@@ -1,0 +1,321 @@
+<?xml version="1.0" standalone="no" ?>
+<hdf5_layout>
+  <global name="detector_data_destination" ndattribute="FrameType" />
+    <group name="exchange">
+      <dataset name="frame_type" source="ndattribute" ndattribute="FrameType" when="OnFileClose" />       
+      <dataset name="data" source="detector">
+        <!-- SaveDest = 0 : /exchange/data -->
+        <attribute name="description" source="constant" value="ImageData" type="string" />
+        <attribute name="axes" source="constant" value="theta:y:x" type="string" />
+        <attribute name="units" source="constant" value="counts" type="string" />
+      </dataset>
+      <dataset name="data_dark" source="detector">
+        <!-- SaveDest = 1 : /exchange/data_dark -->
+        <attribute name="description" source="constant" value="DarkData" type="string" />
+        <attribute name="axes" source="constant" value="theta:y:x" type="string" />
+        <attribute name="units" source="constant" value="counts" type="string" />
+      </dataset>
+      <dataset name="data_white" source="detector">
+        <!-- SaveDest = 2 : /exchange/data_white -->
+        <attribute name="description" source="constant" value="WhiteData" type="string" />
+        <attribute name="axes" source="constant" value="theta:y:x" type="string" />
+        <attribute name="units" source="constant" value="counts" type="string" />
+      </dataset>
+      <!-- theta: 
+            after the file is written, Python will add this new dataset
+            the values will be the (computed) rotation angles for images in data
+            
+            Looks like this:
+                theta:float64[1500] = [0.0, 0.12008005336891261, 0.24016010673782523, '...', 180.0]
+                  @units = degrees
+                  @description = computed rotation stage angle
+      -->
+    </group><!-- /exchange -->
+    
+    <group name="measurement">
+      <group name="instrument">
+        <dataset name="name" source="constant" value="13-BM-D micro-tomography system using PG cameras" type="string" when="OnFileClose" />   
+             
+        <group name="source">
+          <dataset name="beamline" source="constant" value="13-BM-D" type="string" when="OnFileClose" />        
+          <dataset name="name" source="constant" value="Advanced Photon Source" type="string" when="OnFileClose" />        
+          <dataset name="current" source="ndattribute" ndattribute="RingCurrent" when="OnFileClose">        
+            <attribute name="units" source="constant" value="mA" type="string" />
+          </dataset>    
+          <dataset name="top_up" source="ndattribute" ndattribute="TopUpStatus" when="OnFileClose" /> 
+          <dataset name="fill_mode" source="ndattribute" ndattribute="BeamMode" when="OnFileClose" />
+        </group><!-- /source -->
+        
+        <group name="mirror">
+          <dataset name="name" source="constant" value="13-BM-D Mirror" type="string" when="OnFileClose" />        
+          <group name="setup">
+             <dataset name="mirror_x" source="ndattribute" ndattribute="MirrorHeight" when="OnFileClose">       
+               <attribute name="units" source="constant" value="mm" type="string" />
+             </dataset>
+             <dataset name="mirror_y" source="ndattribute" ndattribute="MirrorPitch" when="OnFileClose">       
+               <attribute name="units" source="constant" value="mrad" type="string" />
+             </dataset>  
+             <dataset name="mirror_usy" source="ndattribute" ndattribute="MirrorCurvature" when="OnFileClose">       
+               <attribute name="units" source="constant" value="mm" type="string" />
+             </dataset> 
+             <dataset name="mirror_dsy" source="ndattribute" ndattribute="MirrorEllipticity" when="OnFileClose">       
+               <attribute name="units" source="constant" value="mm" type="string" />             
+             </dataset>
+          </group><!-- /setup -->
+        </group><!-- /mirror -->
+        
+        <group name="attenuator">
+          <dataset name="name" source="constant" value="13-BM-D filters" type="string" when="OnFileClose" />  
+          <group name="setup">
+          <dataset name="user_filter_us" source="ndattribute" ndattribute="Filter" when="OnFileClose"> 
+          </dataset>
+          <dataset name="user_filter_ds" source="ndattribute" ndattribute="FilterMotor" when="OnFileClose"> 
+            <attribute name="units" source="constant" value="mm" type="string" />
+          </dataset>
+          </group><!-- /setup -->
+        </group><!-- /attenuator -->
+        
+        <group name="monochromator">
+          <dataset name="name" source="constant" value="13-BM-D DCM" type="string" when="OnFileClose" />   
+
+          <dataset name="energy" source="ndattribute" ndattribute="Energy" when="OnFileClose">
+            <attribute name="units" source="constant" value="eV" type="string"></attribute>
+          </dataset>
+          <dataset name="energy_mode" source="ndattribute" ndattribute="EnergyMode" when="OnFileClose" />
+          <group name="setup">
+            <dataset name="dcm_beam_offset" source="ndattribute" ndattribute="BeamOffset" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="degree" type="string" />
+            </dataset>
+            <dataset name="dcm_feedback_setpoint" source="ndattribute" ndattribute="MonoFBSetpoint" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="percent" type="string" />
+            </dataset>
+            <dataset name="dcm_feedback_readback" source="ndattribute" ndattribute="MonoFBReadback" when="OnFileWrite"> 
+              <attribute name="units" source="constant" value="percent" type="string" />
+            </dataset>
+            <dataset name="dcm_feedback_status" source="ndattribute" ndattribute="MonoFBOnOff" when="OnFileClose" /> 
+            <dataset name="dcm_keithley_gain" source="ndattribute" ndattribute="KeithleyGain" when="OnFileClose" /> 
+            <dataset name="dcm_keithley_units" source="ndattribute" ndattribute="KeithleyUnits" when="OnFileClose" /> 
+          </group><!-- /setup -->
+        </group><!-- /monochromator -->
+        
+        <group name="slits">
+          <dataset name="name" source="constant" value="Slits" type="string" when="OnFileClose" />        
+          <group name="setup">
+          <dataset name="hslits_ds_size" source="ndattribute" ndattribute="BMDSlitHSize" when="OnFileClose"> 
+            <attribute name="units" source="constant" value="mm" type="string" />
+          </dataset>
+          <dataset name="hslits_ds_center" source="ndattribute" ndattribute="BMDSlitHCenter" when="OnFileClose"> 
+            <attribute name="units" source="constant" value="mm" type="string" />
+          </dataset>
+          <dataset name="vslits_ds_size" source="ndattribute" ndattribute="BMDSlitVSize" when="OnFileClose"> 
+            <attribute name="units" source="constant" value="mm" type="string" />
+          </dataset>
+          <dataset name="vslits_ds_center" source="ndattribute" ndattribute="BMDSlitVCenter" when="OnFileClose"> 
+            <attribute name="units" source="constant" value="mm" type="string" />
+          </dataset>
+          </group><!-- /setup -->
+        </group><!-- /slits -->
+      
+        <group name="sample">
+          <dataset name="name" source="constant" value="microCT sample stages" type="string" when="OnFileClose" />        
+          <dataset name="detector_distance" source="ndattribute" ndattribute="CameraDistance" when="OnFileClose">        
+            <attribute name="units" source="constant" value="mm" type="string" />
+          </dataset>
+          <group name="setup">
+            <dataset name="sample_x" source="ndattribute" ndattribute="SampleX" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="sample_y" source="ndattribute" ndattribute="SampleY" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="sample_rotary" source="ndattribute" ndattribute="SampleOmega" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="deg" type="string" />
+            </dataset>
+            <dataset name="sample_x_cent" source="ndattribute" ndattribute="SampleXCent" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="sample_z_cent" source="ndattribute" ndattribute="SampleZCent" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+          </group><!-- /setup -->
+        </group><!-- /sample -->
+
+        <group name="lift_table">
+          <dataset name="name" source="constant" value="Lift table" type="string" when="OnFileClose" />        
+          <group name="setup">
+            <dataset name="lift_height" source="ndattribute" ndattribute="LiftHeight" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="lift_x" source="ndattribute" ndattribute="LiftX" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="lift_y" source="ndattribute" ndattribute="LiftY" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="lift_z" source="ndattribute" ndattribute="LiftZ" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="lift_ax" source="ndattribute" ndattribute="LiftAX" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="deg" type="string" />
+            </dataset>
+            <dataset name="lift_ay" source="ndattribute" ndattribute="LiftAY" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="deg" type="string" />
+            </dataset>
+            <dataset name="lift_az" source="ndattribute" ndattribute="LiftAZ" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="deg" type="string" />
+            </dataset>
+          </group><!-- /setup -->
+        </group><!-- /sample -->
+        
+        <group name="camera">
+          <dataset name="name" source="constant" value="Camera motors" type="string" when="OnFileClose" />        
+          <group name="setup">
+            <dataset name="camera_x" source="ndattribute" ndattribute="CameraX" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="camera_y" source="ndattribute" ndattribute="CameraY" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="camera_z" source="ndattribute" ndattribute="CameraZ" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="camera_distance" source="ndattribute" ndattribute="CameraDistance" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="camera_rotation" source="ndattribute" ndattribute="CameraRotation" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="deg" type="string" />
+            </dataset>
+          </group><!-- /setup -->
+        </group><!-- /sample -->
+        
+        <group name="detector">
+          <dataset name="manufacturer" source="ndattribute" ndattribute="DetectorManufacturer" when="OnFileClose" />
+          <dataset name="model" source="ndattribute" ndattribute="DetectorModel" when="OnFileClose" />
+          <dataset name="serial_number" source="ndattribute" ndattribute="SerialNumber" when="OnFileClose" />
+          <dataset name="firmware_version" source="ndattribute" ndattribute="FirmwareVersion" when="OnFileClose" />
+          <dataset name="SDK_version" source="ndattribute" ndattribute="SDKVersion" when="OnFileClose" />
+          <dataset name="driver_version" source="ndattribute" ndattribute="DriverVersion" when="OnFileClose" />
+          <dataset name="ADcore_version" source="ndattribute" ndattribute="ADCoreVersion" when="OnFileClose" />
+          <dataset name="HDFplugin_version" source="ndattribute" ndattribute="HDFPluginVersion" when="OnFileClose" />
+
+          <dataset name="dimension_x" source="ndattribute" ndattribute="MaxSizeX" when="OnFileClose" />
+          <dataset name="dimension_y" source="ndattribute" ndattribute="MaxSizeY" when="OnFileClose" />
+          <dataset name="gain" source="ndattribute" ndattribute="Gain" when="OnFileClose" />          
+          <dataset name="gain_auto" source="ndattribute" ndattribute="GainAuto" when="OnFileClose" />          
+          <dataset name="binning_x" source="ndattribute" ndattribute="BinX" when="OnFileClose" />
+          <dataset name="binning_y" source="ndattribute" ndattribute="BinY" when="OnFileClose" />
+          <dataset name="frame_rate" source="ndattribute" ndattribute="FrameRate" when="OnFileClose" /> 
+          <dataset name="frame_rate_enable" source="ndattribute" ndattribute="FrameRateEnable" when="OnFileClose" /> 
+          <dataset name="exposure_time" source="ndattribute" ndattribute="AcquireTime" when="OnFileClose" />
+          <dataset name="acquire_period" source="ndattribute" ndattribute="AcquirePeriod" when="OnFileClose" />
+          <dataset name="exposure_period" source="ndattribute" ndattribute="ExposurePeriod" when="OnFileClose" />
+          <dataset name="pixel_format" source="ndattribute" ndattribute="PixelFormat" when="OnFileClose" />       
+          <dataset name="convert_pixel_format" source="ndattribute" ndattribute="ConvertPixelFormat" when="OnFileClose" />       
+          <dataset name="array_counter" source="ndattribute" ndattribute="ArrayCounter" when="OnFileClose" />       
+          <dataset name="temperature" source="ndattribute" ndattribute="DetectorTemperature" when="OnFileClose">
+            <attribute name="units" source="constant" value="Celsius" type="string"></attribute>
+          </dataset>
+          <dataset name="pixel_size" source="ndattribute" ndattribute="DetectorPixelSize" when="OnFileClose">
+            <attribute name="units" source="constant" value="microns" type="string"></attribute>
+          </dataset>
+
+          <group name="roi">
+            <dataset name="min_x" source="ndattribute" ndattribute="MinX" when="OnFileClose" />
+            <dataset name="size_x" source="ndattribute" ndattribute="SizeX" when="OnFileClose" />
+            <dataset name="min_y" source="ndattribute" ndattribute="MinY" when="OnFileClose" />
+            <dataset name="size_y" source="ndattribute" ndattribute="SizeY" when="OnFileClose" />
+          </group><!-- /roi -->
+          
+        </group><!-- /detector -->
+        <group name="detection_system">
+          <group name="objective">
+            <dataset name="camera_objective" source="ndattribute" ndattribute="CameraObjective" when="OnFileClose" />
+            <dataset name="camera_tube_length" source="ndattribute" ndattribute="CameraTubeLength" when="OnFileClose">
+              <attribute name="units" source="constant" value="mm" type="string"></attribute>
+            </dataset>
+          </group><!-- /objective -->
+          <dataset name="resolution" source="ndattribute" ndattribute="ImagePixelSize" when="OnFileClose">
+            <attribute name="units" source="constant" value="microns" type="string"></attribute>
+          </dataset>
+          <group name="scintillator">
+            <dataset name="name" source="ndattribute" ndattribute="ScintillatorType" when="OnFileClose" />
+            <dataset name="scintillating_thickness" source="ndattribute" ndattribute="ScintillatorThickness" when="OnFileClose" >
+              <attribute name="units" source="constant" value="microns" type="string" />            
+            </dataset>
+          </group><!-- /scintillator -->
+        </group><!-- /detection_system -->
+      </group><!-- /instrument -->
+
+      <group name="sample">
+        <dataset name="name" source="ndattribute" ndattribute="SampleName" when="OnFileClose" />        
+        <dataset name="description_1" source="ndattribute" ndattribute="SampleDescription1" when="OnFileClose" />        
+        <dataset name="description_2" source="ndattribute" ndattribute="SampleDescription2" when="OnFileClose" />        
+        <dataset name="description_3" source="ndattribute" ndattribute="SampleDescription3" when="OnFileClose" />        
+        <dataset name="file_name" source="ndattribute" ndattribute="FileName" when="OnFileClose" />         
+        <dataset name="file_path" source="ndattribute" ndattribute="FilePath" when="OnFileClose" />        
+        <dataset name="full_file_name" source="ndattribute" ndattribute="FullFileName" when="OnFileClose" />         
+        <group name="experimenter">
+           <dataset name="name" source="ndattribute" ndattribute="UserName" when="OnFileClose" />
+           <dataset name="affiliation" source="ndattribute" ndattribute="UserAffiliation" when="OnFileClose" />
+           <dataset name="email" source="ndattribute" ndattribute="UserEmail" when="OnFileClose" />
+           <dataset name="facility_user_id" source="ndattribute" ndattribute="UserBadge" when="OnFileClose" />
+        </group><!-- /experimenter -->
+        <group name="experiment">
+           <dataset name="proposal" source="ndattribute" ndattribute="ProposalNumber" when="OnFileClose" />
+           <dataset name="title" source="ndattribute" ndattribute="ProposalTitle" when="OnFileClose" />
+           <dataset name="ESAF_number" source="ndattribute" ndattribute="ESAFNumber" when="OnFileClose" />
+        </group><!-- /experiment -->
+      </group><!-- /sample -->
+    </group><!-- /measurement -->
+         
+    <group name="process">
+      <group name="acquisition">
+        <dataset name="start_date" source="ndattribute" ndattribute="DateTimeStart" when="OnFileOpen" />
+        <dataset name="end_date" source="ndattribute" ndattribute="DateTimeEnd" when="OnFileClose" />
+        <group name="rotation">
+          <dataset name="rotation_start" source="ndattribute" ndattribute="RotationStart" when="OnFileClose">
+                <attribute name="units" source="constant" value="degrees" type="string" />
+          </dataset>
+          <dataset name="rotation_step" source="ndattribute" ndattribute="RotationStep" when="OnFileClose">
+                <attribute name="units" source="constant" value="degrees" type="string" />
+          </dataset>
+          <dataset name="rotation_speed" source="ndattribute" ndattribute="RotationSpeed" when="OnFileClose">
+                <attribute name="units" source="constant" value="degrees/s" type="string" />
+          </dataset>
+          <dataset name="num_angles" source="ndattribute" ndattribute="NumAngles" when="OnFileClose" />
+          <dataset name="return_rotation" source="ndattribute" ndattribute="ReturnRotation" when="OnFileClose" />
+       </group><!-- /rotation -->
+        <group name="dark_fields">
+          <dataset name="num_dark_fields" source="ndattribute" ndattribute="NumDarkFields" when="OnFileClose" />
+          <dataset name="dark_field_mode" source="ndattribute" ndattribute="DarkFieldMode" when="OnFileClose" />
+          <dataset name="dark_field_value" source="ndattribute" ndattribute="DarkFieldValue" when="OnFileClose">
+                <attribute name="units" source="constant" value="counts" type="string" />
+          </dataset>
+       </group><!-- /dark_fields -->
+        <group name="flat_fields">
+          <dataset name="num_flat_fields" source="ndattribute" ndattribute="NumFlatFields" when="OnFileClose" />
+          <dataset name="flat_field_mode" source="ndattribute" ndattribute="FlatFieldMode" when="OnFileClose" />
+          <dataset name="flat_field_value" source="ndattribute" ndattribute="FlatFieldValue" when="OnFileClose">
+                <attribute name="units" source="constant" value="counts" type="string" />
+          </dataset>
+          <dataset name="flat_field_axis" source="ndattribute" ndattribute="FlatFieldAxis" when="OnFileClose" />
+          <dataset name="sample_in_x" source="ndattribute" ndattribute="SampleInX" when="OnFileClose">
+                <attribute name="units" source="constant" value="mm" type="string" />
+          </dataset>
+          <dataset name="sample_out_x" source="ndattribute" ndattribute="SampleOutX" when="OnFileClose">
+                <attribute name="units" source="constant" value="mm" type="string" />
+          </dataset>
+          <dataset name="sample_in_y" source="ndattribute" ndattribute="SampleInY" when="OnFileClose">
+                <attribute name="units" source="constant" value="mm" type="string" />
+          </dataset>
+          <dataset name="sample_out_y" source="ndattribute" ndattribute="SampleOutY" when="OnFileClose">
+                <attribute name="units" source="constant" value="mm" type="string" />
+          </dataset>
+       </group><!-- /flat_fields -->
+     </group><!-- /acquisition -->
+    </group><!-- /process -->
+
+    <group name="defaults" ndattr_default="true">
+    </group><!-- /defaults -->
+
+</hdf5_layout>

--- a/doc/demo/areadetector/13-BM/tomoLayout.xml
+++ b/doc/demo/areadetector/13-BM/tomoLayout.xml
@@ -77,7 +77,6 @@
         
         <group name="monochromator">
           <dataset name="name" source="constant" value="13-BM-D DCM" type="string" when="OnFileClose" />   
-
           <dataset name="energy" source="ndattribute" ndattribute="Energy" when="OnFileClose">
             <attribute name="units" source="constant" value="eV" type="string"></attribute>
           </dataset>
@@ -165,7 +164,7 @@
               <attribute name="units" source="constant" value="deg" type="string" />
             </dataset>
           </group><!-- /setup -->
-        </group><!-- /sample -->
+        </group><!-- /lift table -->
         
         <group name="camera">
           <dataset name="name" source="constant" value="Camera motors" type="string" when="OnFileClose" />        
@@ -186,7 +185,7 @@
               <attribute name="units" source="constant" value="deg" type="string" />
             </dataset>
           </group><!-- /setup -->
-        </group><!-- /sample -->
+        </group><!-- /camera -->
         
         <group name="detector">
           <dataset name="manufacturer" source="ndattribute" ndattribute="DetectorManufacturer" when="OnFileClose" />
@@ -218,25 +217,24 @@
           <dataset name="pixel_size" source="ndattribute" ndattribute="DetectorPixelSize" when="OnFileClose">
             <attribute name="units" source="constant" value="microns" type="string"></attribute>
           </dataset>
-
           <group name="roi">
             <dataset name="min_x" source="ndattribute" ndattribute="MinX" when="OnFileClose" />
             <dataset name="size_x" source="ndattribute" ndattribute="SizeX" when="OnFileClose" />
             <dataset name="min_y" source="ndattribute" ndattribute="MinY" when="OnFileClose" />
             <dataset name="size_y" source="ndattribute" ndattribute="SizeY" when="OnFileClose" />
-          </group><!-- /roi -->
-          
+          </group><!-- /roi -->    
         </group><!-- /detector -->
+
         <group name="detection_system">
           <group name="objective">
             <dataset name="camera_objective" source="ndattribute" ndattribute="CameraObjective" when="OnFileClose" />
             <dataset name="camera_tube_length" source="ndattribute" ndattribute="CameraTubeLength" when="OnFileClose">
               <attribute name="units" source="constant" value="mm" type="string"></attribute>
             </dataset>
+            <dataset name="resolution" source="ndattribute" ndattribute="ImagePixelSize" when="OnFileClose">
+              <attribute name="units" source="constant" value="microns" type="string"></attribute>
+            </dataset>
           </group><!-- /objective -->
-          <dataset name="resolution" source="ndattribute" ndattribute="ImagePixelSize" when="OnFileClose">
-            <attribute name="units" source="constant" value="microns" type="string"></attribute>
-          </dataset>
           <group name="scintillator">
             <dataset name="name" source="ndattribute" ndattribute="ScintillatorType" when="OnFileClose" />
             <dataset name="scintillating_thickness" source="ndattribute" ndattribute="ScintillatorThickness" when="OnFileClose" >
@@ -244,6 +242,7 @@
             </dataset>
           </group><!-- /scintillator -->
         </group><!-- /detection_system -->
+
       </group><!-- /instrument -->
 
       <group name="sample">

--- a/doc/demo/areadetector/2-BM/DIMAXLayout.xml
+++ b/doc/demo/areadetector/2-BM/DIMAXLayout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no" ?>
-<hdf_layout>
+<hdf5_layout>
   <global name="detector_data_destination" ndattribute="SaveDest" />
     <group name="exchange">
       <dataset name="data" source="detector">
@@ -264,4 +264,4 @@
     <group name="defaults" ndattr_default="true">
     </group><!-- /defaults -->
 
-</hdf_layout>
+</hdf5_layout>

--- a/doc/demo/areadetector/2-BM/PCOLayout.xml
+++ b/doc/demo/areadetector/2-BM/PCOLayout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no" ?>
-<hdf_layout>
+<hdf5_layout>
   <global name="detector_data_destination" ndattribute="SaveDest" />
     <group name="exchange">
       <dataset name="data" source="detector">
@@ -264,4 +264,4 @@
     <group name="defaults" ndattr_default="true">
     </group><!-- /defaults -->
 
-</hdf_layout>
+</hdf5_layout>

--- a/doc/demo/areadetector/2-BM/flir2bmaLayout.xml
+++ b/doc/demo/areadetector/2-BM/flir2bmaLayout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no" ?>
-<hdf_layout>
+<hdf5_layout>
   <global name="detector_data_destination" ndattribute="SaveDest" />
     <group name="exchange">
       <dataset name="data" source="detector">
@@ -264,4 +264,4 @@
     <group name="defaults" ndattr_default="true">
     </group><!-- /defaults -->
 
-</hdf_layout>
+</hdf5_layout>

--- a/doc/demo/areadetector/2-BM/flir2bmbLayout.xml
+++ b/doc/demo/areadetector/2-BM/flir2bmbLayout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no" ?>
-<hdf_layout>
+<hdf5_layout>
   <global name="detector_data_destination" ndattribute="SaveDest" />
     <group name="exchange">
       <dataset name="data" source="detector">
@@ -279,4 +279,4 @@
     <group name="defaults" ndattr_default="true">
     </group><!-- /defaults -->
 
-</hdf_layout>
+</hdf5_layout>

--- a/doc/demo/areadetector/2-BM/monaLayout.xml
+++ b/doc/demo/areadetector/2-BM/monaLayout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no" ?>
-<hdf_layout>
+<hdf5_layout>
   <global name="detector_data_destination" ndattribute="SaveDest" />
     <group name="exchange">
       <dataset name="data" source="detector">
@@ -279,4 +279,4 @@
     <group name="defaults" ndattr_default="true">
     </group><!-- /defaults -->
 
-</hdf_layout>
+</hdf5_layout>

--- a/doc/demo/areadetector/32-ID/mct.xml
+++ b/doc/demo/areadetector/32-ID/mct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no" ?>
-<hdf_layout>
+<hdf5_layout>
   <global name="detector_data_destination" ndattribute="SaveDest"></global>
     <group name="exchange">
       <dataset name="data" source="detector">
@@ -307,6 +307,6 @@
 
     <group name="defaults" ndattr_default="true">
   </group>
-</hdf_layout>
+</hdf5_layout>
 
 

--- a/doc/demo/areadetector/32-ID/nct.xml
+++ b/doc/demo/areadetector/32-ID/nct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no" ?>
-<hdf_layout>
+<hdf5_layout>
   <global name="detector_data_destination" ndattribute="SaveDest"></global>
     <group name="exchange">
       <dataset name="data" source="detector">
@@ -482,5 +482,5 @@
 
     <group name="defaults" ndattr_default="true">
   </group>
-</hdf_layout>
+</hdf5_layout>
 

--- a/doc/demo/areadetector/7-BM/mct3.xml
+++ b/doc/demo/areadetector/7-BM/mct3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no" ?>
-<hdf_layout>
+<hdf5_layout>
   <global name="detector_data_destination" ndattribute="SaveDest"></global>
     <group name="exchange">
       <dataset name="data" source="detector">
@@ -172,43 +172,43 @@
       </group><!-- /instrument -->
       
       <group name="ancillary">
-        <dataset name="MW100_ADC_01" source="ndattribute" ndattribute="MW100_ADC_01" when="OnFrame"> 
+        <dataset name="MW100_ADC_01" source="ndattribute" ndattribute="MW100_ADC_01" when="OnFileWrite"> 
           <attribute name="units" source="ndattribute" ndattribute="MW100_ADC_01_Unit"></attribute>
           <attribute name="description" source="ndattribute" ndattribute="MW100_ADC_01_Desc"></attribute>
         </dataset>	
-        <dataset name="MW100_ADC_02" source="ndattribute" ndattribute="MW100_ADC_02" when="OnFrame"> 
+        <dataset name="MW100_ADC_02" source="ndattribute" ndattribute="MW100_ADC_02" when="OnFileWrite"> 
           <attribute name="units" source="ndattribute" ndattribute="MW100_ADC_02_Unit"></attribute>
           <attribute name="description" source="ndattribute" ndattribute="MW100_ADC_02_Desc"></attribute>
         </dataset>
-        <dataset name="MW100_ADC_03" source="ndattribute" ndattribute="MW100_ADC_03" when="OnFrame"> 
+        <dataset name="MW100_ADC_03" source="ndattribute" ndattribute="MW100_ADC_03" when="OnFileWrite"> 
           <attribute name="units" source="ndattribute" ndattribute="MW100_ADC_03_Unit"></attribute>
           <attribute name="description" source="ndattribute" ndattribute="MW100_ADC_03_Desc"></attribute>
         </dataset>
-        <dataset name="MW100_ADC_04" source="ndattribute" ndattribute="MW100_ADC_04" when="OnFrame"> 
+        <dataset name="MW100_ADC_04" source="ndattribute" ndattribute="MW100_ADC_04" when="OnFileWrite"> 
           <attribute name="units" source="ndattribute" ndattribute="MW100_ADC_04_Unit"></attribute>
           <attribute name="description" source="ndattribute" ndattribute="MW100_ADC_04_Desc"></attribute>
         </dataset>
-        <dataset name="MW100_ADC_05" source="ndattribute" ndattribute="MW100_ADC_05" when="OnFrame"> 
+        <dataset name="MW100_ADC_05" source="ndattribute" ndattribute="MW100_ADC_05" when="OnFileWrite"> 
           <attribute name="units" source="ndattribute" ndattribute="MW100_ADC_05_Unit"></attribute>
           <attribute name="description" source="ndattribute" ndattribute="MW100_ADC_05_Desc"></attribute>
         </dataset>
-        <dataset name="MW100_ADC_06" source="ndattribute" ndattribute="MW100_ADC_06" when="OnFrame"> 
+        <dataset name="MW100_ADC_06" source="ndattribute" ndattribute="MW100_ADC_06" when="OnFileWrite"> 
           <attribute name="units" source="ndattribute" ndattribute="MW100_ADC_06_Unit"></attribute>
           <attribute name="description" source="ndattribute" ndattribute="MW100_ADC_06_Desc"></attribute>
         </dataset>
-        <dataset name="MW100_ADC_07" source="ndattribute" ndattribute="MW100_ADC_07" when="OnFrame"> 
+        <dataset name="MW100_ADC_07" source="ndattribute" ndattribute="MW100_ADC_07" when="OnFileWrite"> 
           <attribute name="units" source="ndattribute" ndattribute="MW100_ADC_07_Unit"></attribute>
           <attribute name="description" source="ndattribute" ndattribute="MW100_ADC_07_Desc"></attribute>
         </dataset>
-        <dataset name="MW100_ADC_08" source="ndattribute" ndattribute="MW100_ADC_08" when="OnFrame"> 
+        <dataset name="MW100_ADC_08" source="ndattribute" ndattribute="MW100_ADC_08" when="OnFileWrite"> 
           <attribute name="units" source="ndattribute" ndattribute="MW100_ADC_08_Unit"></attribute>
           <attribute name="description" source="ndattribute" ndattribute="MW100_ADC_08_Desc"></attribute>
         </dataset>
-        <dataset name="MW100_ADC_09" source="ndattribute" ndattribute="MW100_ADC_09" when="OnFrame"> 
+        <dataset name="MW100_ADC_09" source="ndattribute" ndattribute="MW100_ADC_09" when="OnFileWrite"> 
           <attribute name="units" source="ndattribute" ndattribute="MW100_ADC_09_Unit"></attribute>
           <attribute name="description" source="ndattribute" ndattribute="MW100_ADC_09_Desc"></attribute>
         </dataset>
-        <dataset name="MW100_ADC_10" source="ndattribute" ndattribute="MW100_ADC_10" when="OnFrame"> 
+        <dataset name="MW100_ADC_10" source="ndattribute" ndattribute="MW100_ADC_10" when="OnFileWrite"> 
           <attribute name="units" source="ndattribute" ndattribute="MW100_ADC_10_Unit"></attribute>
           <attribute name="description" source="ndattribute" ndattribute="MW100_ADC_10_Desc"></attribute>
         </dataset>
@@ -227,6 +227,6 @@
 
     <group name="defaults" ndattr_default="true">
   </group>
-</hdf_layout>
+</hdf5_layout>
 
 


### PR DESCRIPTION
This fixes some syntax errors in the HDF5 XML layout files. 

Previously the files would not validate when using xmllint and the areaDetector XSD file.  For example this is ``flir2bmaLayout.xml``.
```
corvette:demo/areadetector/2-BM>xmllint --noout --schema /home/epics/devel/areaDetector/ADCore/XML_schema/hdf5_xml_layout_schema.xsd flir2bmaLayout.xml
flir2bmaLayout.xml:2: element hdf_layout: Schemas validity error : Element 'hdf_layout': No matching global declaration available for the validation root.
flir2bmaLayout.xml fails to validate
```
I replaced hdf_layout with hdf5_layout, which is the correct syntax.
```
diff --git a/doc/demo/areadetector/2-BM/flir2bmaLayout.xml b/doc/demo/areadetector/2-BM/flir2bmaLayout.xml
index 55ce6a8..45702a3 100755
--- a/doc/demo/areadetector/2-BM/flir2bmaLayout.xml
+++ b/doc/demo/areadetector/2-BM/flir2bmaLayout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no" ?>
-<hdf_layout>
+<hdf5_layout>
   <global name="detector_data_destination" ndattribute="SaveDest" />
     <group name="exchange">
       <dataset name="data" source="detector">
@@ -264,4 +264,4 @@
     <group name="defaults" ndattr_default="true">
     </group><!-- /defaults -->

-</hdf_layout>
+</hdf5_layout>
```

The file now validated OK.
```
corvette:demo/areadetector/2-BM>xmllint --noout --schema /home/epics/devel/areaDetector/ADCore/XML_schema/hdf5_xml_layout_schema.xsd flir2bmaLayout.xml
flir2bmaLayout.xml validates
```

The 7-BM mct3.xml file was also using "OnFrame" when it should be "OnFileWrite".

