### PR TITLE
Incorporate changes at 7-BM due to implementation of hexapod

### DIFF
--- a/doc/demo/areadetector/7-BM/TomoScanDetectorAttributes.xml
+++ b/doc/demo/areadetector/7-BM/TomoScanDetectorAttributes.xml
@@ -100,14 +100,15 @@
     <Attribute name="Filter_1_Material"             type="EPICS_PV" source="7bma1:filter1:Position"                    dbrtype="DBR_STRING"/>
     <Attribute name="Filter_2_Material"             type="EPICS_PV" source="7bma1:filter2:Position"                    dbrtype="DBR_STRING"/>
 
-    <Attribute name="SampleX"                       type="EPICS_PV" source="7bmb1:aero:m2.RBV"                         dbrtype="DBR_DOUBLE"/>
-    <Attribute name="SampleY"                       type="EPICS_PV" source="7bmb1:aero:m1.RBV"                         dbrtype="DBR_DOUBLE"/>
-    <Attribute name="CameraX"                       type="EPICS_PV" source="7bmb1:m2.RBV"                              dbrtype="DBR_DOUBLE"/>
-    <Attribute name="CameraY"                       type="EPICS_PV" source="7bmb1:m28.RBV"                              dbrtype="DBR_DOUBLE"/>
+    <Attribute name="SampleX"                       type="EPICS_PV" source="7bmbHXP:m2.RBV"                            dbrtype="DBR_DOUBLE"/>
+    <Attribute name="SampleY"                       type="EPICS_PV" source="7bmbHXP:m3.RBV"                            dbrtype="DBR_DOUBLE"/>
+    <Attribute name="CameraX"                       type="EPICS_PV" source="7bmb1:m28.RBV"                             dbrtype="DBR_DOUBLE"/>
+    <Attribute name="CameraY"                       type="EPICS_PV" source="7bmb1:m7.RBV"                              dbrtype="DBR_DOUBLE"/>
+    <Attribute name="CameraZ"                       type="EPICS_PV" source="7bmb1:aero:m4.RBV"                         dbrtype="DBR_DOUBLE"/>
     <Attribute name="CameraRoll"                    type="EPICS_PV" source="7bmb1:m36.RBV"                             dbrtype="DBR_DOUBLE"/>
     <Attribute name="CameraFocus"                   type="EPICS_PV" source="7bmb1:m35.RBV"                             dbrtype="DBR_DOUBLE"/>
-    <Attribute name="Center0Deg"                    type="EPICS_PV" source="7bmb1:m34.RBV"                             dbrtype="DBR_DOUBLE"/>
-    <Attribute name="Center90Deg"                   type="EPICS_PV" source="7bmb1:m33.RBV"                             dbrtype="DBR_DOUBLE"/>
+    <Attribute name="Center0Deg"                    type="EPICS_PV" source="7bmb1:m33.RBV"                             dbrtype="DBR_DOUBLE"/>
+    <Attribute name="Center90Deg"                   type="EPICS_PV" source="7bmb1:m34.RBV"                             dbrtype="DBR_DOUBLE"/>
     <Attribute name="DS_Table_X0_Motor_Position"    type="EPICS_PV" source="7bmb1:m13.RBV"                             dbrtype="DBR_DOUBLE"/>
     <Attribute name="DS_Table_X2_Motor_Position"    type="EPICS_PV" source="7bmb1:m14.RBV"                             dbrtype="DBR_DOUBLE"/>
     <Attribute name="DS_Table_Y0_Motor_Position"    type="EPICS_PV" source="7bmb1:m16.RBV"                             dbrtype="DBR_DOUBLE"/>

--- a/doc/demo/areadetector/7-BM/TomoScanDetectorAttributes.xml
+++ b/doc/demo/areadetector/7-BM/TomoScanDetectorAttributes.xml
@@ -102,6 +102,7 @@
 
     <Attribute name="SampleX"                       type="EPICS_PV" source="7bmbHXP:m2.RBV"                            dbrtype="DBR_DOUBLE"/>
     <Attribute name="SampleY"                       type="EPICS_PV" source="7bmbHXP:m3.RBV"                            dbrtype="DBR_DOUBLE"/>
+    <Attribute name="SampleBaseY"                   type="EPICS_PV" source="7bmb1:m26.RBV"                             dbrtype="DBR_DOUBLE"/>
     <Attribute name="SampleZ"                       type="EPICS_PV" source="7bmbHXP:m1.RBV"                            dbrtype="DBR_DOUBLE"/>
     <Attribute name="SampleAX"                      type="EPICS_PV" source="7bmbHXP:m5.RBV"                            dbrtype="DBR_DOUBLE"/>
     <Attribute name="SampleAY"                      type="EPICS_PV" source="7bmbHXP:m6.RBV"                            dbrtype="DBR_DOUBLE"/>

--- a/doc/demo/areadetector/7-BM/TomoScanDetectorAttributes.xml
+++ b/doc/demo/areadetector/7-BM/TomoScanDetectorAttributes.xml
@@ -102,6 +102,10 @@
 
     <Attribute name="SampleX"                       type="EPICS_PV" source="7bmbHXP:m2.RBV"                            dbrtype="DBR_DOUBLE"/>
     <Attribute name="SampleY"                       type="EPICS_PV" source="7bmbHXP:m3.RBV"                            dbrtype="DBR_DOUBLE"/>
+    <Attribute name="SampleZ"                       type="EPICS_PV" source="7bmbHXP:m1.RBV"                            dbrtype="DBR_DOUBLE"/>
+    <Attribute name="SampleAX"                      type="EPICS_PV" source="7bmbHXP:m5.RBV"                            dbrtype="DBR_DOUBLE"/>
+    <Attribute name="SampleAY"                      type="EPICS_PV" source="7bmbHXP:m6.RBV"                            dbrtype="DBR_DOUBLE"/>
+    <Attribute name="SampleAZ"                      type="EPICS_PV" source="7bmbHXP:m4.RBV"                            dbrtype="DBR_DOUBLE"/>
     <Attribute name="CameraX"                       type="EPICS_PV" source="7bmb1:m28.RBV"                             dbrtype="DBR_DOUBLE"/>
     <Attribute name="CameraY"                       type="EPICS_PV" source="7bmb1:m7.RBV"                              dbrtype="DBR_DOUBLE"/>
     <Attribute name="CameraZ"                       type="EPICS_PV" source="7bmb1:aero:m4.RBV"                         dbrtype="DBR_DOUBLE"/>

--- a/doc/demo/areadetector/7-BM/TomoScanLayout.xml
+++ b/doc/demo/areadetector/7-BM/TomoScanLayout.xml
@@ -69,6 +69,8 @@
             <dataset name="y" source="ndattribute" ndattribute="CameraY" when="OnFileClose"> 
               <attribute name="units" source="constant" value="mm" type="string" />
             </dataset>
+            <dataset name="z" source="ndattribute" ndattribute="CameraZ" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
             <dataset name="rotation" source="ndattribute" ndattribute="CameraRoll" when="OnFileClose"> 
               <attribute name="units" source="constant" value="°" type="string" />
             </dataset>

--- a/doc/demo/areadetector/7-BM/TomoScanLayout.xml
+++ b/doc/demo/areadetector/7-BM/TomoScanLayout.xml
@@ -71,6 +71,7 @@
             </dataset>
             <dataset name="z" source="ndattribute" ndattribute="CameraZ" when="OnFileClose"> 
               <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
             <dataset name="rotation" source="ndattribute" ndattribute="CameraRoll" when="OnFileClose"> 
               <attribute name="units" source="constant" value="°" type="string" />
             </dataset>

--- a/doc/demo/areadetector/7-BM/TomoScanLayout.xml
+++ b/doc/demo/areadetector/7-BM/TomoScanLayout.xml
@@ -131,6 +131,9 @@
             <dataset name="y" source="ndattribute" ndattribute="SampleY" when="OnFileClose"> 
               <attribute name="units" source="constant" value="mm" type="string" />
             </dataset>
+            <dataset name="base_y" source="ndattribute" ndattribute="SampleBaseY" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
             <dataset name="z" source="ndattribute" ndattribute="SampleZ" when="OnFileClose"> 
               <attribute name="units" source="constant" value="mm" type="string" />
             </dataset>

--- a/doc/demo/areadetector/7-BM/TomoScanLayout.xml
+++ b/doc/demo/areadetector/7-BM/TomoScanLayout.xml
@@ -131,6 +131,18 @@
             <dataset name="y" source="ndattribute" ndattribute="SampleY" when="OnFileClose"> 
               <attribute name="units" source="constant" value="mm" type="string" />
             </dataset>
+            <dataset name="z" source="ndattribute" ndattribute="SampleZ" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="theta_x" source="ndattribute" ndattribute="SampleAX" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="theta_y" source="ndattribute" ndattribute="SampleAY" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
+            <dataset name="theta_z" source="ndattribute" ndattribute="SampleAZ" when="OnFileClose"> 
+              <attribute name="units" source="constant" value="mm" type="string" />
+            </dataset>
             <dataset name="Center0Deg" source="ndattribute" ndattribute="Center0Deg" when="OnFileClose"> 
               <attribute name="units" source="constant" value="mm" type="string" />
             </dataset>


### PR DESCRIPTION
I made several changes to the 7-BM XML file to reflect new motor assignments due to the implementation of the Aerotech hexapod as the sample stage at 7-BM, as well as changes to the camera motor stack.